### PR TITLE
scan all refered usernames in note text

### DIFF
--- a/lib/gitlab-irc.rb
+++ b/lib/gitlab-irc.rb
@@ -86,10 +86,11 @@ post '/' do
       message += "View #{json['object_attributes']['url']}"
       say message
     when 'note'
-      next unless json['object_attributes']['note'] =~ /@(?<username>\w+)/
-      message = "[#{json['project']['name']}] Mentioned to #{Regexp.last_match[:username]} : "
-      message += "View #{json['object_attributes']['url']}"
-      say message
+      json['object_attributes']['note'].to_s.scan(/@(\w+)/).flatten.each do |username|
+        message = "[#{json['project']['name']}] Mentioned to #{username} : "
+        message += "View #{json['object_attributes']['url']}"
+        say message
+      end
     end
 
     status 200


### PR DESCRIPTION
### Summary

I updated `lib/gitlab-irc.rb`: scan all refered usernames in the note text.
### Examples
#### Example 1. some usernames

If the note text is as following, `foo`, `bar`, and `foobar` are captured.

```
@foo @bar
@foobar

Hello.
```
#### Example 2. a username

If the note text is as following, only `foo` is captured.

```
@foo

Hello.
```
#### Example 3. no username

If the note text is as following, nothing is captured.

```
Hello.
```
### Notes

I don't care about duplicated usernames. If the note text is as following, `foo` and `foo` are captured.

```
@foo
@foo

Hello.
```
